### PR TITLE
Updating sass sourcemap stuff

### DIFF
--- a/gulp/tasks/development/sass.js
+++ b/gulp/tasks/development/sass.js
@@ -1,8 +1,7 @@
 var gulp         = require('gulp');
-var plumber      = require('gulp-plumber');
-var browsersync  = require('browser-sync');
+var browserSync  = require('browser-sync');
+var glob         = require('glob');
 var sass         = require('gulp-ruby-sass');
-var gulpFilter   = require('gulp-filter');
 var autoprefixer = require('gulp-autoprefixer');
 var sourcemaps   = require('gulp-sourcemaps');
 var config       = require('../../config');
@@ -11,23 +10,34 @@ var config       = require('../../config');
  * Generate CSS from SCSS
  * Build sourcemaps
  */
-gulp.task('sass', function() {
+gulp.task('sass', function(callback) {
   var sassConfig = config.sass.options;
 
   sassConfig.onError = browsersync.notify;
 
-  // Don’t write sourcemaps of sourcemaps
-  var filter = gulpFilter(['*.css', '!*.map']);
-
   browsersync.notify('Compiling Sass');
-
-  return gulp.src(config.sass.src)
-    .pipe(plumber())
-    .pipe(sass(sassConfig))
-    .pipe(sourcemaps.init())
+  
+  glob(config.sass.src, function (er, files) {
+    sassQueue = files.length;
+    files.forEach(sassCompile);
+  });
+  
+  function reportFinished() {
+    if(sassQueue) {
+      sassQueue--;
+      if(sassQueue === 0) {
+        // If queue is empty, tell gulp the task is complete.
+        // https://github.com/gulpjs/gulp/blob/master/docs/API.md#accept-a-callback
+        callback();
+      }
+    }
+  };
+  
+  function sassCompile(filename) {
+    sass(filename, sassConfig)
     .pipe(autoprefixer(config.autoprefixer))
-    .pipe(filter) // Don’t write sourcemaps of sourcemaps
     .pipe(sourcemaps.write('.', { includeContent: false }))
-    .pipe(filter.restore()) // Restore original files
-    .pipe(gulp.dest(config.sass.dest));
+    .pipe(gulp.dest(config.sass.dest))
+    .on('finish', reportFinished);
+  }
 });


### PR DESCRIPTION
gulp-ruby-sass v1.0.0-alpha2 which is what you get nowadays when you install via npm has changed it's api

Calling `sass(filename, options)` directly does the job of `gulp.src( without glob support yet )` and `sourcemap.init()`.
All my efforts to pass stuff in via gulp.src resulted in garbled sourcemaps, even your solution. This works beautifully.

gulp-ruby-sass doesn't support plumber any more, and onError does the almost the same thing anyway.

Hopefully we won't have to refactor this again to support future changes anytime soon. I can't tell you how much time I wasted before figuring this out.