### PR TITLE
Better task end detection

### DIFF
--- a/gulp/tasks/development/scripts.js
+++ b/gulp/tasks/development/scripts.js
@@ -43,7 +43,7 @@ gulp.task('scripts', function(callback) {
         .pipe(source(bundleConfig.outputName))
         // Specify the output destination
         .pipe(gulp.dest(bundleConfig.dest))
-        .on('end', reportFinished);
+        .on('finish', reportFinished);
     };
 
     if(global.isWatching) {


### PR DESCRIPTION
`on('end', ...)` didn't work for me.